### PR TITLE
Add query_params

### DIFF
--- a/lib/elastic/client.rb
+++ b/lib/elastic/client.rb
@@ -77,13 +77,14 @@ module Elastic
       execute { bulk(options) }
     end
 
-    def bulk_operation(action, index, id, data = {})
+    def bulk_operation(action, index, id, data = {}, query_params = {})
       metadata = {
         _index: index,
         _id:    id,
       }
 
       metadata[:data] = data if data && !data.empty?
+      metadata.merge!(query_params) unless query_params.empty?
 
       { action.to_sym => metadata }
     end
@@ -92,7 +93,7 @@ module Elastic
       execute { get(id: id, index: index) }
     end
 
-    def mget(index, ids)
+    def mget(index, ids, query_params = {})
       ids = Array(ids)
       return [] if ids.empty?
 
@@ -104,6 +105,8 @@ module Elastic
           docs: docs
         }
       }
+
+      options.merge!(query_params) unless query_params.empty?
 
       results = execute { mget(options) }
       results['docs'].select { |doc| doc['found'] }

--- a/spec/elastic/index_spec.rb
+++ b/spec/elastic/index_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Elastic::Index do
 
     it "marks index as not dirty" do
       # First, ensure it is marked as dirty
-      subject.bulk(:index, '1', { 'foo' => 'bar' })
+      subject.bulk(:index, '1', data: { 'foo' => 'bar' })
       subject.buffer.flush!
 
       expect {
@@ -142,15 +142,15 @@ RSpec.describe Elastic::Index do
       allow(subject).to receive(:client) { s }
       expect(s).to receive(:bulk).once
 
-      subject.bulk(:index, '1', { 'foo' => 'bar' })
-      subject.bulk(:index, '2', { 'abc' => 'xyz' })
+      subject.bulk(:index, '1', data: { 'foo' => 'bar' })
+      subject.bulk(:index, '2', data: { 'abc' => 'xyz' })
 
       subject.buffer.flush!
     end
 
     it "marks index as dirty after executing operations" do
       expect {
-        subject.bulk(:index, '1', { 'foo' => 'bar' })
+        subject.bulk(:index, '1', data: { 'foo' => 'bar' })
         subject.buffer.flush!
       }.to change { subject.dirty? }.from(false).to(true)
     end
@@ -169,38 +169,41 @@ RSpec.describe Elastic::Index do
     end
 
     it "builds index operation" do
-      operation = subject.bulk_operation(:index, 'id', { 'foo' => 'bar' })
+      operation = subject.bulk_operation(:index, 'id', { 'foo' => 'bar' }, { routing: 'foo' })
 
       expect(operation).to \
         eq(index: {
           _index: subject.index_name,
           _id:    'id',
           retry_on_conflict: 3,
-          data:   { 'foo' => 'bar' }
+          data:   { 'foo' => 'bar' },
+          routing: 'foo'
         })
     end
 
     it "builds update operation" do
-      operation = subject.bulk_operation(:update, 'id', doc: { 'foo' => 'bar' })
+      operation = subject.bulk_operation(:update, 'id', { doc: { 'foo' => 'bar' } }, { routing: 'foo'})
 
       expect(operation).to \
         eq(update: {
           _index: subject.index_name,
           _id:    'id',
           retry_on_conflict: 3,
-          data:   { doc: { 'foo' => 'bar' } }
+          data:   { doc: { 'foo' => 'bar' } },
+          routing: 'foo'
         })
     end
 
     it "builds upsert operation" do
-      operation = subject.bulk_operation(:upsert, 'id', doc: { 'foo' => 'bar' })
+      operation = subject.bulk_operation(:upsert, 'id', { doc: { 'foo' => 'bar' } }, { routing: 'foo' })
 
       expect(operation).to \
         eq(update: {
           _index: subject.index_name,
           _id:    'id',
           retry_on_conflict: 3,
-          data:   { doc_as_upsert: true, doc: { 'foo' => 'bar' } }
+          data:   { doc_as_upsert: true, doc: { 'foo' => 'bar' } },
+          routing: 'foo'
         })
     end
   end


### PR DESCRIPTION
Main goal of this PR is add ability to pass routing param in query

```
Index#get(id, query_params: { routing: 'ANS' })
Index#mget(id, query_params: { routing: 'ANS' })

Index#bulk(:update, '123', data: { doc: { archived: true } }, query_params: { routing: 'ANS' })
```

documents and document_ids are using scroll which doesn't need routing param